### PR TITLE
Add explicit audit criteria definitions to `google3-audits.toml`.

### DIFF
--- a/manual-sources/google3-audits.toml
+++ b/manual-sources/google3-audits.toml
@@ -1,3 +1,82 @@
+[criteria.crypto-safe]
+description = """
+All crypto algorithms in this crate have been reviewed by a relevant expert.
+**Note**: If a crate does not implement crypto, use `does-not-implement-crypto`,
+which implies `crypto-safe`, but does not require expert review in order to
+audit for."""
+
+[criteria.does-not-implement-crypto]
+description = """
+Inspection reveals that the crate in question does not attempt to implement any
+cryptographic algorithms on its own.
+Note that certification of this does not require an expert on all forms of
+cryptography: it's expected for crates we import to be \"good enough\" citizens,
+so they'll at least be forthcoming if they try to implement something
+cryptographic. When in doubt, please ask an expert."""
+implies = "crypto-safe"
+
+[criteria.ub-risk-0]
+description = """
+No unsafe code.
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-0
+"""
+implies = "ub-risk-1"
+
+[criteria.ub-risk-1]
+description = """
+Excellent soundness.
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-1
+"""
+implies = "ub-risk-2"
+
+[criteria.ub-risk-1-thorough]
+description = """
+Excellent soundness (established in a thorough review).
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-1-thorough
+"""
+implies = "ub-risk-1"
+
+[criteria.ub-risk-2]
+description = """
+Negligible unsoundness or average soundness.
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-2
+"""
+implies = "ub-risk-3"
+
+[criteria.ub-risk-2-thorough]
+description = """
+Negligible unsoundness or average soundness (established in a thorough review).
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-2-thorough
+"""
+implies = "ub-risk-2"
+
+[criteria.ub-risk-3]
+description = """
+Mild unsoundness or suboptimal soundness.
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-3
+"""
+implies = "ub-risk-4"
+
+[criteria.ub-risk-4]
+description = """
+Extreme unsoundness.
+
+Full description of the audit criteria can be found at
+https://github.com/google/rust-crate-audits/blob/main/auditing_standards.md#ub-risk-4
+"""
+
 [[audits.android_logger]]
 who = "Manish Goregaokar <manishearth@gmail.com>"
 criteria = ["ub-risk-3", "does-not-implement-crypto"]


### PR DESCRIPTION
Fixes https://github.com/google/rust-crate-audits/issues/12.

After this commit `google3-audits.toml` becomes usable on its own (i.e. this commit allows direct import of `google3-audits.toml` - such a direct import may be important for projects that are in the `sources.list`).

The criteria descriptions comes from the following sources:

* `ub-risk-N`: Criteria descriptions have been copied from https://fuchsia-review.git.corp.google.com/c/fuchsia/+/995606
* `crypto-safe` and `does-not-implement-crypto`: Criteria descriptions have been copied from https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml
* `ub-risk-N-thorough`: Criteria descriptions have been authored from scratch - this is okay, because these criteria are not currently used in other `audits.toml` files (i.e. are not used by ChromiumOS nor Fuchsia).