### PR TITLE
Update CI cache action to v4

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update stable && rustup default stable
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/cargo-vet
         key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}


### PR DESCRIPTION
The cache storage has been rewritten to a new architecture and the v1 and v2 packages are now unsupported.