### PR TITLE
Improve the description of ub-risk-3

### DIFF
--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -225,7 +225,7 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
 
  * Is only triggered on platforms that the codebase does not care about.
  * May only become a problem in future versions of Rust, by which time there is confidence that it will have been patched..
- * Is triggered by a pattern of use which the project discourages and can confidently avoid long-term
+ * Is triggered by a pattern of use which the project discourages and can confidently avoid long-term.
 
 
 All audit levels should strive to detail the safety issues found. However, those details are especially important for `ub-risk-3` audits because projects depend on those details to determine whether high-risk crates are acceptable to use.

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -228,7 +228,7 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
  * Unsoundness that is triggered by a particular pattern of use of an API, which the codebase does not care to do and is confident of being able to avoid long term.
 
 
-This is true for all audit levels, but `ub-risk-3` audits in particular should strive to contain audit comments detailing the safety issues found, to aid in such judgement calls.
+All audit levels should strive to detail the safety issues found. However, those details are especially important for `ub-risk-3` audits because projects depend on those details to determine whether high-risk crates are acceptable to use.
 
 ### `ub-risk-4`
 

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -223,9 +223,9 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
 
 `ub-risk-3` is the highest risk level at which non-experts could reasonably avoid causing undefined behavior. These crates are unsound, but the risk they pose may be acceptable in some situations. Projects need to make judgement calls about where, when, and by whom these crates may be used. For example, a project may deem a `ub-risk-3` crate acceptable to use if it contains unsoundness that:
 
- * Unsoundness that is only triggered on platforms that the codebase does not care about.
- * Unsoundness that may become a problem in future versions of Rust, where the codebase is confident of having upstream patches by then.
- * Unsoundness that is triggered by a particular pattern of use of an API, which the codebase does not care to do and is confident of being able to avoid long term.
+ * Is only triggered on platforms that the codebase does not care about.
+ * May only become a problem in future versions of Rust, by which time there is confidence that it will have been patched..
+ * Is triggered by a pattern of use which the project discourages and can confidently avoid long-term
 
 
 All audit levels should strive to detail the safety issues found. However, those details are especially important for `ub-risk-3` audits because projects depend on those details to determine whether high-risk crates are acceptable to use.

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -221,7 +221,7 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
 *   Some caution may be required to avoid undefined behavior.
 
 
-`ub-risk-3` is expected to live at the threshold of acceptance as a dependency for most codebases: there is unsoundness in the crate, but there are also many situations where one need not worry about that unsoundness ever being triggered, and the codebase needs to make a judgement call. For example, one may choose to depend on a `ub-risk-3` dep if the rating is due to:
+`ub-risk-3` is the highest risk level at which non-experts could reasonably avoid causing undefined behavior. These crates are unsound, but the risk they pose may be acceptable in some situations. Projects need to make judgement calls about where, when, and by whom these crates may be used. For example, a project may deem a `ub-risk-3` crate acceptable to use if it contains unsoundness that:
 
  * Unsoundness that is only triggered on platforms that the codebase does not care about.
  * Unsoundness that may become a problem in future versions of Rust, where the codebase is confident of having upstream patches by then.

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -203,7 +203,7 @@ Also called: "Mild unsoundness", "Suboptimal soundness"
 
 Requires **Unsafe Rust expertise**
 
-Crates with this criteria contain unsafe Rust code which doesn't uphold the typical standards required for unsafe code. They MAY pose a risk of causing undefined behavior, and probably should be allowed on a case-by-case basis based on usage.
+Crates with this criteria contain unsafe Rust code which doesn't uphold the typical standards required for unsafe code. They pose a nontrivial, but not necessarily unacceptable risk of causing undefined behavior. Projects are encouraged to allow the use of these crates on a case-by-case basis, based on their own specific constraints.
 
 #### Criteria guidelines
 

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -224,7 +224,7 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
 `ub-risk-3` is the highest risk level at which non-experts could reasonably avoid causing undefined behavior. These crates are unsound, but the risk they pose may be acceptable in some situations. Projects need to make judgement calls about where, when, and by whom these crates may be used. For example, a project may deem a `ub-risk-3` crate acceptable to use if it contains unsoundness that:
 
  * Is only triggered on platforms that the codebase does not care about.
- * May only become a problem in future versions of Rust, by which time there is confidence that it will have been patched..
+ * May only become a problem in future versions of Rust, by which time there is confidence that it will have been patched.
  * Is triggered by a pattern of use which the project discourages and can confidently avoid long-term.
 
 

--- a/auditing_standards.md
+++ b/auditing_standards.md
@@ -203,7 +203,7 @@ Also called: "Mild unsoundness", "Suboptimal soundness"
 
 Requires **Unsafe Rust expertise**
 
-Crates with this criteria contain unsafe Rust code which doesn't uphold the typical standards required for unsafe code. They pose a significant risk of causing undefined behavior, and are suitable only for select applications.
+Crates with this criteria contain unsafe Rust code which doesn't uphold the typical standards required for unsafe code. They MAY pose a risk of causing undefined behavior, and probably should be allowed on a case-by-case basis based on usage.
 
 #### Criteria guidelines
 
@@ -218,7 +218,17 @@ Crates with this criteria contain unsafe Rust code which doesn't uphold the typi
     *   Writing implementations of traits not marked `unsafe` by violating documented invariants.
     *   Writing implementations of traits not marked `unsafe` that are not really intended to be implemented by the user.
     *   Explicitly forgetting values that have important drop behavior to cause UB when combined with operations that would not be expected to follow normally.
-*   A fair amount of caution may be required to avoid undefined behavior.
+*   Some caution may be required to avoid undefined behavior.
+
+
+`ub-risk-3` is expected to live at the threshold of acceptance as a dependency for most codebases: there is unsoundness in the crate, but there are also many situations where one need not worry about that unsoundness ever being triggered, and the codebase needs to make a judgement call. For example, one may choose to depend on a `ub-risk-3` dep if the rating is due to:
+
+ * Unsoundness that is only triggered on platforms that the codebase does not care about.
+ * Unsoundness that may become a problem in future versions of Rust, where the codebase is confident of having upstream patches by then.
+ * Unsoundness that is triggered by a particular pattern of use of an API, which the codebase does not care to do and is confident of being able to avoid long term.
+
+
+This is true for all audit levels, but `ub-risk-3` audits in particular should strive to contain audit comments detailing the safety issues found, to aid in such judgement calls.
 
 ### `ub-risk-4`
 
@@ -226,7 +236,7 @@ Also called: "Extreme unsoundness", "Very risky"
 
 Requires **Unsafe Rust expertise**
 
-Crates with this criteria contain very dangerous unsafe rust code.
+Crates with this criteria contain very dangerous unsafe rust code. They pose a risk of causing undefined behavior with typical use.
 
 #### Criteria guidelines
 


### PR DESCRIPTION
Discussed with @djkoloski: I realized that there was a bit of a tension between my interpretation of ub-risk-3 and the documented text, in particular I did not think the flavortext was accurately matching the concrete, normative criteria.

I've updated with more flavortext, explaining that ub-risk-3 is expected to be _on the threshold_ of acceptance: the crate has problems, but _based on your codebase_ you might easily have legitimate reasons to allow it anyway.